### PR TITLE
Limit asmdef IncludePlatforms to Editor only

### DIFF
--- a/Editor/LilytechLab.CmponentIconInHierarchy.Editor.asmdef
+++ b/Editor/LilytechLab.CmponentIconInHierarchy.Editor.asmdef
@@ -2,7 +2,9 @@
     "name": "LilytechLab.ComponentIconInHierarchy.Editor",
     "rootNamespace": "LilytechLab.ComponentIconInHierarchy.Editor",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
# Changes
- fix  `includePlatforms` in `LilytechLab.ComponentIconInHierarchy.Editor.asmdef`
  - The asmdef for Editor should be restricted to be executed only by Editor.